### PR TITLE
changes onStepperInputChanged to look for .btn-glyph instead of .btn-number

### DIFF
--- a/src/game/UIFunctions.js
+++ b/src/game/UIFunctions.js
@@ -470,12 +470,12 @@ function (Ash, GlobalSignals, GameConstants, UIConstants, ItemConstants, PlayerA
             }
             
             if(valueCurrent >= minValue) {
-                $(".btn-number[data-type='minus'][data-field='"+name+"']").removeAttr('disabled')
+                $(".btn-glyph[data-type='minus'][data-field='"+name+"']").removeAttr('disabled')
             } else {
                 $(this).val(minValue);
             }
             if(valueCurrent <= maxValue) {
-                $(".btn-number[data-type='plus'][data-field='"+name+"']").removeAttr('disabled')
+                $(".btn-glyph[data-type='plus'][data-field='"+name+"']").removeAttr('disabled')
             } else {
                 $(this).val(maxValue);
             }


### PR DESCRIPTION
Just a small change. I noticed that the stepper arrows wouldn't reliably un-disable themselves, and it looks like it's because this function was looking for `.btn-number` even though the buttons are assigned `.btn-glyph` in their constructor. This just changes that. I've verified locally that this does correct the issue.

To reproduce the issue, just get a camp with at least 2 members, set both to collect water, remove one, and you shouldn't be able to add any more until you remove the `disabled` attribute from the button.