### PR TITLE
fixes notification-player and progress-bar line-height

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1291,7 +1291,6 @@ hr {
   border-style: solid;
   margin-top: 5px;
   margin-bottom: 5px;
-  line-height: 1.3;
 }
 #notification-player .progress {
   width: 100%;
@@ -1479,6 +1478,7 @@ select {
   max-width: 250px;
   height: 1em;
   border-width: 0px !important;
+  line-height: 1.3;
 }
 .golden-small .progress {
   max-width: 100%;

--- a/css/main.css
+++ b/css/main.css
@@ -1291,6 +1291,7 @@ hr {
   border-style: solid;
   margin-top: 5px;
   margin-bottom: 5px;
+  line-height: 1.3;
 }
 #notification-player .progress {
   width: 100%;

--- a/css/main.less
+++ b/css/main.less
@@ -1371,7 +1371,6 @@ hr {
     border-style: solid;
     margin-top: 5px;
     margin-bottom: 5px;
-    line-height: 1.3;
 }
 
 #notification-player .progress {
@@ -1595,6 +1594,7 @@ select {
 	max-width: 250px;
 	height: 1em;
 	border-width: 0px !important;
+	line-height: 1.3;
 }
 
 .golden-small .progress {

--- a/css/main.less
+++ b/css/main.less
@@ -1371,6 +1371,7 @@ hr {
     border-style: solid;
     margin-top: 5px;
     margin-bottom: 5px;
+    line-height: 1.3;
 }
 
 #notification-player .progress {


### PR DESCRIPTION
Whenever line-height is set with a unit it breaks the inheritance of relative line-heights. This means that the `line-height: 1.3em` rule on `body` causes the line-height to be set to `1.3em` of the body font-size across the entire document. This causes the progress bar and notification player to have a line-height larger than its box size when its height is set to `1em` and its font-size is set to `85%`.

The fix is to simply redeclare line-height as a unitless number. `line-height: 1.3em` and `line-height: 1.3` are functionally equivalent on a given element. With the only difference being how they are inherited downstream.

Unfortunately, I checked with simply removing the unit from the `body` declaration, and it changes the formatting of the entire page. I figured I'd play it safe and just set it for this one set of elements. Also, I was uncertain which file was being used primarily since the css file was updated most recently, so I went ahead and just added the rule to both.

Before: 
![image](https://user-images.githubusercontent.com/15902166/37858101-3b2e8878-2ed7-11e8-8b5b-8661a17f40f9.png)

After:
![image](https://user-images.githubusercontent.com/15902166/37858108-4a93eefc-2ed7-11e8-9e04-6d40ed2a5954.png)

Cheers!
