### PR TITLE
Fix bar animations

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1345,7 +1345,6 @@ button .cooldown-duration {
   top: 0px;
   left: 0px;
   padding: 0;
-  transition: all 0.1s;
 }
 /* -- Appearance: All-purpose elements -- */
 table.fullwidth {

--- a/css/main.less
+++ b/css/main.less
@@ -1413,7 +1413,6 @@ button .cooldown-action, button .cooldown-duration {
 	top: 0px;
 	left: 0px;
 	padding: 0;
-	transition: all 0.1s;
 }
 
 


### PR DESCRIPTION
This is a fix for #50.  I found this [stackoverflow issue](https://stackoverflow.com/questions/35103735/jquery-animation-only-shows-when-mouse-is-moving) that details the same problem, and it turns out that the solution is removing the `transition: all` CSS from `button .cooldown-duration`.   For some reason jQuery doesn't like animating things that have a transition applied to them.