### PR TITLE
Make resource management unselectable

### DIFF
--- a/css/modules/base-classes.less
+++ b/css/modules/base-classes.less
@@ -11,6 +11,13 @@
     display: none;
 }
 
+.unselectable {
+    -webkit-user-select: none; /* Safari */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Standard */
+}    
+
 .full-width {
 	width: 100%;
 }

--- a/src/game/helpers/PlayerActionResultsHelper.js
+++ b/src/game/helpers/PlayerActionResultsHelper.js
@@ -517,7 +517,7 @@ define([
 			}
 
 			if (resultVO.gainedResources.getTotal() > 0 || resultVO.gainedItems.length > 0 || !isInitialSelectionValid) {
-				var baghtml = "<div id='resultlist-inventorymanagement'>";
+				var baghtml = "<div id='resultlist-inventorymanagement' class='unselectable'>";
 
 				baghtml += "<div id='resultlist-inventorymanagement-found' class='infobox inventorybox'>";
 				baghtml += "<ul></ul>";


### PR DESCRIPTION
Hello and thanks for making this awesome game!

My one current frustration is that when managing resources in the world, at times I want to select a certain amount of items (given I still am using the plastic bag at level 12, so I have limited inventory). When I click quickly on the resources, it selects the text and makes my extensions act up. This PR serves as a temporary solution by making that text unselectable. I think adding scroll support/Minecraft-like interface would work (right-click for half, shift-click for all, etc).