### PR TITLE
Fix consolation prize in cases where nothing at all was found

### DIFF
--- a/src/game/helpers/PlayerActionResultsHelper.js
+++ b/src/game/helpers/PlayerActionResultsHelper.js
@@ -319,11 +319,7 @@ define([
 		},
 
 		collectRewards: function (isTakeAll, rewards, campSector) {
-			if (rewards == null || rewards.isEmpty()) {
-				return;
-			}
-			
-			if (rewards.action == "scavenge") {
+			if (rewards && rewards.action == "scavenge") {
 				var excursionComponent = this.playerResourcesNodes.head.entity.get(ExcursionComponent);
 				if (excursionComponent) {
 					if (this.isSomethingUsefulResult(rewards)) {
@@ -332,6 +328,10 @@ define([
 						excursionComponent.numConsecutiveScavengeUseless++;
 					}
 				}
+			}
+			
+			if (rewards == null || rewards.isEmpty()) {
+				return;
 			}
 			
 			var nearestCampNode = this.nearestCampNodes.head;


### PR DESCRIPTION
I noticed the "consolation prize" code doesn't run when repeatedly finding nothing when scavenging.  This change fixes that bug.